### PR TITLE
Add bosh link to job

### DIFF
--- a/jobs/go-cf-api/spec
+++ b/jobs/go-cf-api/spec
@@ -10,6 +10,12 @@ templates:
 packages:
 - go-cf-api
 
+provides:
+- name: go_cf_api
+  type: go_cf_api
+  properties:
+  - cc.public_tls.port
+
 consumes:
 - name: database
   type: database


### PR DESCRIPTION
For the load tests a bosh link is needed, to retrieve the address and port of the go-api VM.